### PR TITLE
Support extended unicode escape sequences

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 // crates.io
 use thiserror::Error as ThisError;
 
-#[cfg(test)] mod test;
+#[cfg(test)]
+mod test;
 
 /// Unescaper's `Result`.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -107,8 +108,7 @@ impl Unescaper {
 		}
 
 		char::from_u32(
-			u16::from_str_radix(&unicode, 16).map_err(|e| ParseIntError { source: e, pos: 0 })?
-				as _,
+			u32::from_str_radix(&unicode, 16).map_err(|e| ParseIntError { source: e, pos: 0 })?,
 		)
 		.ok_or(Error::InvalidChar {
 			char: unicode.chars().last().expect("empty unicode will exit earlier; qed"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
 // crates.io
 use thiserror::Error as ThisError;
 
-#[cfg(test)]
-mod test;
+#[cfg(test)] mod test;
 
 /// Unescaper's `Result`.
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/test.rs
+++ b/src/test.rs
@@ -56,6 +56,8 @@ fn unescape_unicode() {
 	unescape_assert_eq!(r"\u{9}", "\t");
 	unescape_assert_eq!(r"\u{a}", "\n");
 	unescape_assert_eq!(r"\u{ffff}", "\u{ffff}");
+	unescape_assert_eq!(r"\u{1F600}", "\u{1F600}");
+	unescape_assert_eq!(r"\u{1F600}", "😀");
 	unescape_assert_eq!(r"\u{0}XavierJane", "\0XavierJane");
 }
 


### PR DESCRIPTION
Allows the user to specify extended unicode escape sequences using the brace-notation to allow supporting unicode values that are larger than 4 hexadecimal digits such as emojis.