### PR TITLE
Clean up license information in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [
 	"string",
 	"unescape",
 ]
-license = "GPL-3.0/MIT"
+license = "GPL-3.0-only OR MIT"
 name = "unescaper"
 readme = "README.md"
 repository = "https://github.com/hack-ink/unescaper"


### PR DESCRIPTION
TIL multiple licenses are supposed to be separated by OR and that GPL-3.0 got deprecated in favor of GPL-3.0-only and GPL-3.0-or-later. As there is no mention of 'or later' anywhere in the repo, I'm assuming GPL-3.0 only.

I stumbled upon this when looking at issues with cargo-deny in some CI builds.