### PR TITLE
Use modern SPDX license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [
 	"string",
 	"unescape",
 ]
-license = "GPL-3.0/MIT"
+license = "MIT OR GPL-3.0-only"
 name = "unescaper"
 readme = "README.md"
 repository = "https://github.com/hack-ink/unescaper"


### PR DESCRIPTION
## Summary
- replace deprecated `GPL-3.0/MIT` license expression with `MIT OR GPL-3.0-only`
- keep the existing dual-license intent while using modern SPDX syntax

Fixes #71

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo test --locked`
- `cargo clippy --workspace --all-features --all-targets --locked`
- `cargo package --allow-dirty`
- subagent review completed before PR creation