### PR TITLE
Support vertical tab escapes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ impl Unescaper {
 				'n' => '\n',
 				'r' => '\r',
 				't' => '\t',
+				'v' => '\u{000b}',
 				// https://github.com/hack-ink/unescaper/pull/10#issuecomment-1676443635
 				//
 				// https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf

--- a/src/test.rs
+++ b/src/test.rs
@@ -86,6 +86,7 @@ fn unescape_special_symbols() {
 	unescape_assert_eq!(r"\n", "\n");
 	unescape_assert_eq!(r"\r", "\r");
 	unescape_assert_eq!(r"\t", "\t");
+	unescape_assert_eq!(r"\v", "\u{000b}");
 	unescape_assert_eq!(r"\'", "\'");
 	unescape_assert_eq!(r#"\""#, "\"");
 	unescape_assert_eq!(r"\\", "\\");


### PR DESCRIPTION
## Summary
- add support for `\v` as vertical tab (`U+000B`)
- cover the escape in the special-symbol tests

Fixes #70

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo test --locked`
- `cargo clippy --workspace --all-features --all-targets --locked`
- subagent review completed before PR creation