### PR TITLE
Align README with Decodex format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 <div align="center">
 
 # Unescaper
-### Unescape strings with escape sequences written out as literal characters.
 
-[![License GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+Unescape strings with escape sequences written out as literal characters.
+
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Checks](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml)
+[![License GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hack-ink/unescaper)](https://github.com/hack-ink/unescaper/tags)
-[![GitHub code lines](https://tokei.rs/b1/github/hack-ink/unescaper)](https://github.com/hack-ink/unescaper)
 [![GitHub last commit](https://img.shields.io/github/last-commit/hack-ink/unescaper?color=red&style=plastic)](https://github.com/hack-ink/unescaper)
+[![GitHub code lines](https://tokei.rs/b1/github/hack-ink/unescaper)](https://github.com/hack-ink/unescaper)
+[![Checks](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml)
 
 </div>
 
 ## Usage
+
 [More Examples](src/test.rs)
+
 ```rust
 fn main() {
 	assert_eq!(unescaper::unescape(r"\u000a").unwrap(), "\n");
@@ -24,8 +27,35 @@ fn main() {
 }
 ```
 
-## Thanks
-The idea comes from [unescape-rs](https://github.com/saghm/unescape-rs).<br>
-The last commit of that repository was seven years ago.<br>
-So, I think it is no longer maintained.<br>
-That's why I created this repository, and I have made some improvements.
+## Support Me
+
+If you find this project helpful and would like to support its development, you can buy me a coffee!
+
+Your support is greatly appreciated and motivates me to keep improving this project.
+
+- **Fiat**
+    - [Ko-fi](https://ko-fi.com/hack_ink)
+    - [Afdian](https://afdian.com/a/hack_ink)
+- **Crypto**
+    - **Bitcoin**
+        - `bc1pedlrf67ss52md29qqkzr2avma6ghyrt4jx9ecp9457qsl75x247sqcp43c`
+    - **Ethereum**
+        - `0x3e25247CfF03F99a7D83b28F207112234feE73a6`
+    - **Polkadot**
+        - `156HGo9setPcU2qhFMVWLkcmtCEGySLwNqa3DaEiYSWtte4Y`
+
+Thank you for your support!
+
+## Appreciation
+
+We would like to extend our heartfelt gratitude to the following projects and contributors:
+
+- [unescape-rs](https://github.com/saghm/unescape-rs) for the original idea this crate builds on.
+
+<div align="right">
+
+### License
+
+<sup>Licensed under [MIT](LICENSE-MIT) or [GPL-3.0-only](LICENSE-GPL3).</sup>
+
+</div>


### PR DESCRIPTION
## Summary
- adjust the README header and badge ordering toward the Decodex README format
- replace the old Thanks section with Support Me and Appreciation sections
- add the right-aligned License footer using this crate dual-license files

Reference format: https://github.com/hack-ink/decodex#readme

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo test --locked`