### PR TITLE
style: remove import section comments

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,5 @@
-// std
 use std::error::Error as _;
 
-// hack-ink
 use crate::Error::{IncompleteStr, InvalidChar};
 
 macro_rules! unescape_assert_eq {


### PR DESCRIPTION
## Summary
- remove Rust import section comments like `// std` and `// hack-ink`
- verify no matching import section comments remain in the repository

## Validation
- cargo make check
- rg -n "^//\s*(std|core|alloc|crates\.io|hack-ink|crate|super|self|external|local|third.party|third-party|workspace)\s*$" .
- rg -n "^\s*#\s*(std|core|alloc|crates\.io|hack-ink|crate|super|self|external|local|third.party|third-party|workspace)\s*$" .