### PR TITLE
docs: align readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Unescape strings with escape sequences written out as literal characters.
 
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![License GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Checks](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml)
+[![Release](https://github.com/hack-ink/unescaper/actions/workflows/release.yml/badge.svg)](https://github.com/hack-ink/unescaper/actions/workflows/release.yml)
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hack-ink/unescaper)](https://github.com/hack-ink/unescaper/tags)
 [![GitHub last commit](https://img.shields.io/github/last-commit/hack-ink/unescaper?color=red&style=plastic)](https://github.com/hack-ink/unescaper)
-[![Checks](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml/badge.svg?branch=main)](https://github.com/hack-ink/unescaper/actions/workflows/checks.yml)
 
 </div>
 


### PR DESCRIPTION
## Summary
- align README badge ordering with Hack Ink repository style
- add the Release workflow badge
- keep the code-lines badge omitted

## Validation
- rg -n "tokei|code lines|codelines|actions/workflows/release.yml|actions/workflows/checks.yml" README.md