### PR TITLE
chore: release 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR GPL-3.0-only"
 name = "unescaper"
 readme = "README.md"
 repository = "https://github.com/hack-ink/unescaper"
-version = "0.1.8"
+version = "0.1.9"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Summary
- bump crate version to 0.1.9
- update Cargo.lock package version for the release tag

## Validation
- cargo make check
- cargo publish --dry-run --locked --allow-dirty
- cargo metadata --locked --format-version 1 --no-deps
- cargo info unescaper from a temp directory shows crates.io currently has 0.1.8, so 0.1.9 is available for publishing