### PR TITLE
Harden GitHub Actions token permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,6 +17,9 @@ on:
       - main
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   cargo-checks:
     name: Task cargo ${{ matrix.action }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,14 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Publish


### PR DESCRIPTION
## Summary
- add explicit read-only GITHUB_TOKEN permissions to the checks workflow
- add read-only default permissions to the release workflow
- grant contents: write only to the release-publishing job

## Code scanning
Fixes CodeQL alerts #4, #6, and #7 for actions/missing-workflow-permissions.

## Validation
- git diff --check
- ruby Psych YAML parse for both workflows
- actionlint .github/workflows/checks.yml .github/workflows/release.yml