### PR TITLE
chore: release 0.1.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Publish
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
-          discussion_category_name: Announcements
           generate_release_notes: true
 
   publish-on-crates-io:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "unescaper"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR GPL-3.0-only"
 name = "unescaper"
 readme = "README.md"
 repository = "https://github.com/hack-ink/unescaper"
-version = "0.1.9"
+version = "0.1.10"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Summary
- bump crate version to 0.1.10
- update Cargo.lock package version
- remove the Release workflow discussion category setting that made v0.1.9 release finalization fail

## Validation
- cargo make check
- cargo publish --dry-run --locked --allow-dirty
- cargo metadata --locked --format-version 1 --no-deps
- git diff --check