### PR TITLE
Prepare unescaper 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 env:
+  CACHE_VERSION: 0
+
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CARGO_TERM_COLOR: always
 
@@ -15,8 +17,60 @@ permissions:
   contents: read
 
 jobs:
+  cargo-checks:
+    name: Task cargo ${{ matrix.action }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        action: [clippy, fmt, nextest, vstyle]
+    steps:
+      - name: Fetch latest code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup build environment
+        if: matrix.action != 'fmt'
+        run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        if: matrix.action != 'fmt'
+        with:
+          prefix-key: release-${{ env.CACHE_VERSION }}
+          key: ${{ matrix.action }}
+      - name: Install cargo-make
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        with:
+          tool: cargo-make
+      - name: Install taplo
+        if: matrix.action == 'fmt'
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        with:
+          tool: taplo
+      - name: Cargo clippy
+        if: matrix.action == 'clippy'
+        run: cargo make lint-rust
+      - name: Cargo fmt
+        if: matrix.action == 'fmt'
+        run: |
+          rustup toolchain install nightly
+          rustup component add rustfmt --toolchain nightly
+          cargo make fmt-check
+      - name: Install cargo-nextest
+        if: matrix.action == 'nextest'
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        with:
+          tool: nextest
+      - name: Cargo nextest
+        if: matrix.action == 'nextest'
+        run: cargo make test-rust
+      - name: Install cargo-vstyle
+        if: matrix.action == 'vstyle'
+        run: cargo install --git https://github.com/hack-ink/vibe-style --rev f509613696c60fbc5e444072469024888d91d88b --locked
+      - name: Cargo vstyle
+        if: matrix.action == 'vstyle'
+        run: cargo make lint-vstyle-rust
+
   release:
     name: Release
+    needs: publish-on-crates-io
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -28,6 +82,7 @@ jobs:
 
   publish-on-crates-io:
     name: Publish on crates.io
+    needs: cargo-checks
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,120 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +124,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -21,6 +160,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +249,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -52,9 +285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unescaper"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
+ "proptest",
  "thiserror",
 ]
 
@@ -63,3 +303,62 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR GPL-3.0-only"
 name = "unescaper"
 readme = "README.md"
 repository = "https://github.com/hack-ink/unescaper"
-version = "0.1.10"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,3 +27,6 @@ lto      = true
 
 [dependencies]
 thiserror = { version = "2.0" }
+
+[dev-dependencies]
+proptest = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Unescape strings with escape sequences written out as literal characters.
 
 ## Usage
 
-[More Examples](src/test.rs)
-
 ```rust
 fn main() {
 	assert_eq!(unescaper::unescape(r"\u000a").unwrap(), "\n");
@@ -26,6 +24,19 @@ fn main() {
 	assert_eq!(unescaper::unescape_lossy(r"\q\n"), "\\q\n");
 }
 ```
+
+Supported escapes:
+
+| Escape | Output |
+| --- | --- |
+| `\b`, `\f`, `\n`, `\r`, `\t`, `\v` | ASCII control characters |
+| `\'`, `\"`, `\\`, `\/` | Literal quote, backslash, or slash |
+| `\u000a`, `\u{a}` | Unicode scalar values |
+| `\x0a` | Byte values |
+| `\12` | Octal byte values |
+
+`unescape` returns an error for malformed escapes. `unescape_lossy` decodes valid escapes and
+preserves malformed escapes as written.
 
 ## Support Me
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,41 @@
 #![warn(missing_docs)]
 
-//! Unescape the given string.
-//! This is the opposite operation of [`std::ascii::escape_default`].
+//! Unescape strings with escape sequences written out as literal characters.
+//!
+//! Supports common control escapes, quotes, backslashes, solidus, Unicode, byte, and octal escapes.
 
 use std::num::ParseIntError;
 
 /// Unescaper's `Result`.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-/// Unescaper's `Error`.
-#[allow(missing_docs)]
+/// Unescaper's error.
+///
+/// Position fields are zero-based parser break positions in the original input. Incomplete and
+/// numeric escape failures may point to the end of an escape sequence rather than the exact
+/// invalid digit.
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	/// The input ended before the escape sequence completed.
 	#[error("incomplete str, break at {0}")]
 	IncompleteStr(usize),
+	/// The escape sequence resolved to an invalid character.
 	#[error("invalid char, {char:?} break at {pos}")]
-	InvalidChar { char: char, pos: usize },
+	InvalidChar {
+		/// Invalid character or the last character from an invalid numeric escape payload.
+		char: char,
+		/// Zero-based parser break position.
+		pos: usize,
+	},
+	/// The numeric escape payload could not be parsed.
 	#[error("parse int error, break at {pos}")]
-	ParseIntError { source: ParseIntError, pos: usize },
+	ParseIntError {
+		/// Integer parsing failure from the numeric escape payload.
+		source: ParseIntError,
+		/// Zero-based parser break position.
+		pos: usize,
+	},
 }
 
 enum LossyEscape {
@@ -26,7 +43,7 @@ enum LossyEscape {
 	Literal(usize),
 }
 
-/// Unescaper struct which holding the chars cache for unescaping.
+/// Stateful unescaper that owns a reversed character cache.
 #[derive(Debug)]
 pub struct Unescaper {
 	/// [`str`] cache, in reverse order.
@@ -91,12 +108,20 @@ impl Unescaper {
 
 		// \u + { + regex(d*) + }
 		if c == '{' {
+			let mut closed = false;
+
 			while let Some(n) = self.chars.pop() {
 				if n == '}' {
+					closed = true;
+
 					break;
 				}
 
 				unicode.push(n);
+			}
+
+			if !closed {
+				Err(Error::IncompleteStr(0))?;
 			}
 		} else {
 			// [0, 65536), 16^4
@@ -249,18 +274,7 @@ fn parse_lossy_unicode_escape(s: &str, after_marker: usize) -> LossyEscape {
 				.map_or(LossyEscape::Literal(len), |char| LossyEscape::Escaped { char, len });
 		}
 
-		let len = incomplete_braced_unicode_escape_len(s, digits_start);
-
-		if len == s.len() {
-			let digits = &s[digits_start..];
-
-			return u32::from_str_radix(digits, 16)
-				.ok()
-				.and_then(char::from_u32)
-				.map_or(LossyEscape::Literal(len), |char| LossyEscape::Escaped { char, len });
-		}
-
-		return LossyEscape::Literal(len);
+		return LossyEscape::Literal(incomplete_braced_unicode_escape_len(s, digits_start));
 	}
 
 	let Some((digits, len)) = fixed_width_escape_digits(&s[after_marker..], 4) else {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,7 @@
 use std::error::Error as _;
 
+use proptest::{collection, prelude};
+
 use crate::Error::{IncompleteStr, InvalidChar};
 
 macro_rules! unescape_assert_eq {
@@ -23,15 +25,61 @@ macro_rules! unescape_assert_err_str {
 	}};
 }
 
+macro_rules! unescape_assert_invalid_pos {
+	($l:expr, $r:expr) => {
+		let InvalidChar { pos, .. } = crate::unescape($l).unwrap_err() else {
+			panic!("expected invalid char error");
+		};
+
+		assert_eq!(pos, $r);
+	};
+}
+
+proptest::proptest! {
+	#[test]
+	fn escape_default_round_trips_for_chars(c in prelude::any::<char>()) {
+		let escaped = c.escape_default().collect::<String>();
+
+		proptest::prop_assert_eq!(crate::unescape(&escaped).unwrap(), c.to_string());
+	}
+
+	#[test]
+	fn escape_default_round_trips_for_strings(
+		chars in collection::vec(prelude::any::<char>(), 0..64)
+	) {
+		let source = chars.into_iter().collect::<String>();
+		let escaped = source.escape_default().collect::<String>();
+
+		proptest::prop_assert_eq!(crate::unescape(&escaped).unwrap(), source);
+	}
+}
+
 #[test]
 fn strict_errors() {
 	unescape_assert_err!(r"\", IncompleteStr(0));
+	unescape_assert_err!(r"\x", IncompleteStr(1));
+	unescape_assert_err!(r"\x0", IncompleteStr(3));
 	unescape_assert_err!(r"\0\", IncompleteStr(2));
+	unescape_assert_err!(r"\u{", IncompleteStr(2));
+	unescape_assert_err!(r"\u{12", IncompleteStr(4));
 	unescape_assert_err!(r"\{}", InvalidChar { char: '{', pos: 1 });
 	unescape_assert_err!(r"\0\{}", InvalidChar { char: '{', pos: 3 });
+	unescape_assert_invalid_pos!(r"\u{D800}", 7);
+	unescape_assert_invalid_pos!(r"\u{110000}", 9);
+	unescape_assert_err!("é\\q", InvalidChar { char: 'q', pos: 2 });
+	unescape_assert_err_str!(
+		r"\u{}",
+		"parse int error, break at 3",
+		"cannot parse integer from empty string"
+	);
 	unescape_assert_err_str!(
 		r"\u{g}",
 		"parse int error, break at 4",
+		"invalid digit found in string"
+	);
+	unescape_assert_err_str!(
+		r"\xzz",
+		"parse int error, break at 3",
 		"invalid digit found in string"
 	);
 	unescape_assert_err_str!(
@@ -44,14 +92,21 @@ fn strict_errors() {
 #[test]
 fn unescape_unicode() {
 	unescape_assert_eq!(r"\u0000", "\0");
+	unescape_assert_eq!(r"\u0001", "\u{0001}");
 	unescape_assert_eq!(r"\u0009", "\t");
 	unescape_assert_eq!(r"\u000a", "\n");
+	unescape_assert_eq!(r"\u007f", "\u{007f}");
+	unescape_assert_eq!(r"\u0080", "\u{0080}");
 	unescape_assert_eq!(r"\uffff", "\u{ffff}");
 	unescape_assert_eq!(r"\u0000XavierJane", "\0XavierJane");
 	unescape_assert_eq!(r"\u{0}", "\0");
+	unescape_assert_eq!(r"\u{1}", "\u{0001}");
 	unescape_assert_eq!(r"\u{9}", "\t");
 	unescape_assert_eq!(r"\u{a}", "\n");
+	unescape_assert_eq!(r"\u{7f}", "\u{007f}");
+	unescape_assert_eq!(r"\u{80}", "\u{0080}");
 	unescape_assert_eq!(r"\u{ffff}", "\u{ffff}");
+	unescape_assert_eq!(r"\u{10ffff}", "\u{10ffff}");
 	unescape_assert_eq!(r"\u{1F600}", "\u{1F600}");
 	unescape_assert_eq!(r"\u{1F600}", "😀");
 	unescape_assert_eq!(r"\u{0}XavierJane", "\0XavierJane");
@@ -60,18 +115,29 @@ fn unescape_unicode() {
 #[test]
 fn unescape_byte() {
 	unescape_assert_eq!(r"\x00", "\x00");
+	unescape_assert_eq!(r"\x01", "\x01");
 	unescape_assert_eq!(r"\x09", "\t");
 	unescape_assert_eq!(r"\x0a", "\n");
 	unescape_assert_eq!(r"\x7f", "\x7f");
+	unescape_assert_eq!(r"\x80", "\u{0080}");
+	unescape_assert_eq!(r"\xff", "\u{00ff}");
 	unescape_assert_eq!(r"\x00XavierJane", "\x00XavierJane");
 }
 
 #[test]
 fn unescape_octal() {
 	unescape_assert_eq!(r"\0", "\0");
+	unescape_assert_eq!(r"\00", "\0");
+	unescape_assert_eq!(r"\000", "\0");
+	unescape_assert_eq!(r"\7", "\u{0007}");
 	unescape_assert_eq!(r"\11", "\t");
 	unescape_assert_eq!(r"\12", "\n");
+	unescape_assert_eq!(r"\177", "\u{007f}");
+	unescape_assert_eq!(r"\200", "\u{0080}");
 	unescape_assert_eq!(r"\377", "\u{00ff}");
+	// Leading 4..7 consumes at most one following octal digit; the next digit remains literal.
+	unescape_assert_eq!(r"\400", " 0");
+	unescape_assert_eq!(r"\777", "?7");
 	unescape_assert_eq!(r"\0XavierJane", "\0XavierJane");
 }
 
@@ -86,7 +152,7 @@ fn unescape_special_symbols() {
 	unescape_assert_eq!(r"\'", "\'");
 	unescape_assert_eq!(r#"\""#, "\"");
 	unescape_assert_eq!(r"\\", "\\");
-	unescape_assert_eq!(r"//", "//");
+	unescape_assert_eq!(r"\/", "/");
 }
 
 #[test]
@@ -94,12 +160,18 @@ fn unescape_lossy() {
 	assert_eq!(crate::unescape_lossy(r"a\nb"), "a\nb");
 	assert_eq!(crate::unescape_lossy(r"a\qb\nc"), "a\\qb\nc");
 	assert_eq!(crate::unescape_lossy(r"\u{g}\n"), "\\u{g}\n");
+	assert_eq!(crate::unescape_lossy(r"\u{}"), r"\u{}");
+	assert_eq!(crate::unescape_lossy(r"\u{é}"), r"\u{é}");
 	assert_eq!(crate::unescape_lossy(r"\u{110000}\n"), "\\u{110000}\n");
-	assert_eq!(crate::unescape_lossy(r"\u{a"), "\n");
-	assert_eq!(crate::unescape_lossy(r"\u{1F600"), "😀");
+	assert_eq!(crate::unescape_lossy(r"x\u{a"), r"x\u{a");
+	assert_eq!(crate::unescape_lossy(r"\u{a"), r"\u{a");
+	assert_eq!(crate::unescape_lossy(r"\u{1F600"), r"\u{1F600");
 	assert_eq!(crate::unescape_lossy(r"\u{12\n"), "\\u{12\n");
 	assert_eq!(crate::unescape_lossy(r"\u12\n"), "\\u12\n");
 	assert_eq!(crate::unescape_lossy(r"\x0a\xzz"), "\n\\xzz");
+	assert_eq!(crate::unescape_lossy(r"\x"), r"\x");
+	assert_eq!(crate::unescape_lossy(r"\x0"), r"\x0");
 	assert_eq!(crate::unescape_lossy(r"abc\"), "abc\\");
+	assert_eq!(crate::unescape_lossy(r"\8"), r"\8");
 	assert_eq!(crate::unescape_lossy(r"\377"), "\u{00ff}");
 }


### PR DESCRIPTION
## Summary
- Fix strict and lossy braced Unicode handling for malformed escapes
- Document supported escape grammar and parser break positions
- Add focused boundary tests and escape_default round-trip property tests
- Require release tag checks before publish and GitHub release creation
- Bump crate version to 0.2.0

## Validation
- cargo make check
- cargo package --locked --allow-dirty
- release.yml YAML parse

Breaking: malformed incomplete braced Unicode escapes are now preserved/rejected instead of decoded.