### PR TITLE
dep-roll

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,12 +40,12 @@ jobs:
           prefix-key: ${{ env.CACHE_VERSION }}
           key: ${{ matrix.action }}
       - name: Install cargo-make
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: cargo-make
       - name: Install taplo
         if: matrix.action == 'fmt'
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: taplo
       - name: Cargo clippy
@@ -59,7 +59,7 @@ jobs:
           cargo make fmt-check
       - name: Install cargo-nextest
         if: matrix.action == 'nextest'
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: nextest
       - name: Cargo nextest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
           prefix-key: release-${{ env.CACHE_VERSION }}
           key: ${{ matrix.action }}
       - name: Install cargo-make
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: cargo-make
       - name: Install taplo
         if: matrix.action == 'fmt'
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: taplo
       - name: Cargo clippy
@@ -55,7 +55,7 @@ jobs:
           cargo make fmt-check
       - name: Install cargo-nextest
         if: matrix.action == 'nextest'
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c
         with:
           tool: nextest
       - name: Cargo nextest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ inherits = "release"
 lto      = true
 
 [dependencies]
-thiserror = { version = "2.0" }
+thiserror = { version = "2.0.18" }
 
 [dev-dependencies]
-proptest = { version = "1.0" }
+proptest = { version = "1.11.0" }


### PR DESCRIPTION
## Summary
- pin Cargo direct dependency constraints to current published versions
- roll taiki-e/install-action pins to v2.82.10 full SHA

## Validation
- cargo make check

## Dependency coverage
- covers Dependabot PR #90 for taiki-e/install-action 2.82.8 -> 2.82.10